### PR TITLE
Add Modbus simulator implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# Build outputs
+/server
+*.exe
+*.out
+*.test
+
+# IDE/editor files
+.vscode/
+.idea/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,63 @@
-# modbus-simulator
+# Modbus Simulator
+
+This repository provides a lightweight Modbus TCP server simulator written in Go.
+Register addresses and CSV data bindings are configured using a TOML file. The
+simulator reads data from a CSV file and periodically updates the Modbus
+registers with the configured values.
+
+## Features
+
+- Minimal Modbus TCP server that supports reading coils, discrete inputs,
+  holding registers, and input registers.
+- TOML configuration to define server settings, update interval, and register
+  bindings.
+- CSV-driven data updates that cycle through rows on a fixed interval.
+
+## Getting Started
+
+1. **Install Go** – version 1.20 or later is recommended.
+2. **Clone** this repository and change into the project directory.
+3. **Create a configuration file** based on `config.example.toml`.
+4. **Prepare a CSV file** containing the columns referenced in the
+   configuration.
+
+```
+# Example
+cp config.example.toml config.toml
+```
+
+The example configuration references `data/example_data.csv`, which contains
+sample telemetry rows.
+
+## Running the simulator
+
+```
+go run ./cmd/server --config config.toml
+```
+
+The server listens on the address configured in the TOML file (default `:1502`)
+and will rotate through the CSV rows on the configured interval, updating the
+Modbus register values accordingly.
+
+Use any Modbus TCP client to read from the configured registers. The simulator
+supports the following Modbus function codes:
+
+- `0x01` – Read Coils
+- `0x02` – Read Discrete Inputs
+- `0x03` – Read Holding Registers
+- `0x04` – Read Input Registers
+
+## Configuration Reference
+
+- `csv_file`: Path to the CSV file containing data rows.
+- `update_interval`: Go duration string that controls how often registers are
+  updated (e.g., `"5s"`).
+- `[server]` section:
+  - `listen_address`: TCP address for the Modbus server (default `:1502`).
+- `[[registers]]` array:
+  - `type`: Register type (`holding`, `input`, `coil`, or `discrete`).
+  - `address`: Register address to update.
+  - `csv_column`: Column name in the CSV file to use for the register value.
+
+The simulator loops through the CSV rows continuously. Coil and discrete input
+values treat any non-zero CSV value as `true`.

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,0 +1,222 @@
+package main
+
+import (
+	"context"
+	"encoding/csv"
+	"errors"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"os/signal"
+	"strconv"
+	"sync"
+	"syscall"
+	"time"
+
+	"modbus-simulator/internal/config"
+	"modbus-simulator/internal/modbus"
+)
+
+type registerValue struct {
+	regType string
+	address uint16
+	column  string
+}
+
+type simulator struct {
+	cfg          config.Config
+	server       *modbus.Server
+	values       []registerValue
+	dataRows     []map[string]uint16
+	updatePeriod time.Duration
+	mu           sync.Mutex
+	rowIndex     int
+}
+
+func main() {
+	var configPath string
+	flag.StringVar(&configPath, "config", "config.toml", "Path to configuration file")
+	flag.Parse()
+
+	if err := run(configPath); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func run(configPath string) error {
+	cfg, err := config.Load(configPath)
+	if err != nil {
+		return fmt.Errorf("load config: %w", err)
+	}
+
+	sim, err := newSimulator(cfg)
+	if err != nil {
+		return fmt.Errorf("create simulator: %w", err)
+	}
+	defer sim.Close()
+
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- sim.Start(ctx)
+	}()
+
+	select {
+	case <-ctx.Done():
+		log.Println("shutting down simulator")
+		return nil
+	case err := <-errCh:
+		return err
+	}
+}
+
+func newSimulator(cfg config.Config) (*simulator, error) {
+	duration, err := time.ParseDuration(cfg.UpdateInterval)
+	if err != nil {
+		return nil, fmt.Errorf("invalid update interval: %w", err)
+	}
+
+	server := modbus.NewServer()
+	if err := server.Listen(cfg.Server.ListenAddress); err != nil {
+		return nil, fmt.Errorf("start modbus server: %w", err)
+	}
+
+	values := make([]registerValue, len(cfg.Registers))
+	for i, reg := range cfg.Registers {
+		switch reg.Type {
+		case "holding", "input", "coil", "discrete":
+		default:
+			server.Close()
+			return nil, fmt.Errorf("unsupported register type %s", reg.Type)
+		}
+		values[i] = registerValue{regType: reg.Type, address: reg.Address, column: reg.CSVColumn}
+	}
+
+	rows, err := loadCSV(cfg.CSVFile)
+	if err != nil {
+		server.Close()
+		return nil, fmt.Errorf("load csv: %w", err)
+	}
+
+	sim := &simulator{
+		cfg:          cfg,
+		server:       server,
+		values:       values,
+		dataRows:     rows,
+		updatePeriod: duration,
+	}
+
+	return sim, nil
+}
+
+func loadCSV(path string) ([]map[string]uint16, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	reader := csv.NewReader(file)
+	records, err := reader.ReadAll()
+	if err != nil {
+		return nil, err
+	}
+	if len(records) < 2 {
+		return nil, errors.New("csv must contain header and at least one data row")
+	}
+
+	header := records[0]
+	rows := make([]map[string]uint16, 0, len(records)-1)
+	for _, record := range records[1:] {
+		if len(record) != len(header) {
+			return nil, errors.New("csv record length mismatch")
+		}
+		row := make(map[string]uint16, len(header))
+		for i, key := range header {
+			val, err := strconv.ParseUint(record[i], 10, 16)
+			if err != nil {
+				return nil, fmt.Errorf("invalid value for column %s: %w", key, err)
+			}
+			row[key] = uint16(val)
+		}
+		rows = append(rows, row)
+	}
+	return rows, nil
+}
+
+func (s *simulator) Start(ctx context.Context) error {
+	ticker := time.NewTicker(s.updatePeriod)
+	defer ticker.Stop()
+
+	log.Printf("Modbus simulator listening on %s", s.cfg.Server.ListenAddress)
+
+	s.applyRow(0)
+
+	for {
+		select {
+		case <-ticker.C:
+			s.nextRow()
+		case <-ctx.Done():
+			return nil
+		}
+	}
+}
+
+func (s *simulator) nextRow() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if len(s.dataRows) == 0 {
+		return
+	}
+
+	s.rowIndex = (s.rowIndex + 1) % len(s.dataRows)
+	s.applyRowLocked(s.rowIndex)
+}
+
+func (s *simulator) applyRow(index int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.applyRowLocked(index)
+}
+
+func (s *simulator) applyRowLocked(index int) {
+	if len(s.dataRows) == 0 {
+		return
+	}
+	row := s.dataRows[index]
+	for _, value := range s.values {
+		val, ok := row[value.column]
+		if !ok {
+			log.Printf("column %s not found in csv data", value.column)
+			continue
+		}
+		switch value.regType {
+		case "holding":
+			if err := s.server.SetHoldingRegister(value.address, val); err != nil {
+				log.Printf("set holding register: %v", err)
+			}
+		case "input":
+			if err := s.server.SetInputRegister(value.address, val); err != nil {
+				log.Printf("set input register: %v", err)
+			}
+		case "coil":
+			if err := s.server.SetCoil(value.address, val > 0); err != nil {
+				log.Printf("set coil: %v", err)
+			}
+		case "discrete":
+			if err := s.server.SetDiscreteInput(value.address, val > 0); err != nil {
+				log.Printf("set discrete input: %v", err)
+			}
+		default:
+			log.Printf("unsupported register type %s", value.regType)
+		}
+	}
+}
+
+func (s *simulator) Close() {
+	s.server.Close()
+}

--- a/config.example.toml
+++ b/config.example.toml
@@ -1,0 +1,25 @@
+csv_file = "data/example_data.csv"
+update_interval = "3s"
+
+[server]
+listen_address = ":1502"
+
+[[registers]]
+type = "holding"
+address = 1
+csv_column = "temperature"
+
+[[registers]]
+type = "input"
+address = 0
+csv_column = "humidity"
+
+[[registers]]
+type = "coil"
+address = 5
+csv_column = "pump"
+
+[[registers]]
+type = "discrete"
+address = 2
+csv_column = "alarm"

--- a/data/example_data.csv
+++ b/data/example_data.csv
@@ -1,0 +1,5 @@
+temperature,humidity,pump,alarm
+21,55,0,0
+22,58,1,0
+23,60,1,1
+24,57,0,0

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module modbus-simulator
+
+go 1.24.3

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,161 @@
+package config
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+type Config struct {
+	Server         ServerSettings
+	Registers      []RegisterConfig
+	CSVFile        string
+	UpdateInterval string
+}
+
+type ServerSettings struct {
+	ListenAddress string
+}
+
+type RegisterConfig struct {
+	Type      string
+	Address   uint16
+	CSVColumn string
+}
+
+func Load(path string) (Config, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return Config{}, err
+	}
+	defer file.Close()
+
+	cfg := Config{}
+	currentSection := ""
+	scanner := bufio.NewScanner(file)
+	lineNum := 0
+	for scanner.Scan() {
+		lineNum++
+		line := strings.TrimSpace(scanner.Text())
+		if idx := strings.Index(line, "#"); idx >= 0 {
+			line = strings.TrimSpace(line[:idx])
+		}
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+			section := strings.Trim(line, "[]")
+			if strings.HasPrefix(section, "[") && strings.HasSuffix(section, "]") {
+				section = strings.Trim(section, "[]")
+			}
+			if section == "registers" && strings.HasPrefix(line, "[[") {
+				cfg.Registers = append(cfg.Registers, RegisterConfig{})
+				currentSection = "registers"
+			} else if section == "server" {
+				currentSection = "server"
+			} else {
+				return Config{}, fmt.Errorf("unsupported section %s on line %d", section, lineNum)
+			}
+			continue
+		}
+
+		parts := strings.SplitN(line, "=", 2)
+		if len(parts) != 2 {
+			return Config{}, fmt.Errorf("invalid line %d: %s", lineNum, line)
+		}
+		key := strings.TrimSpace(parts[0])
+		value := strings.TrimSpace(parts[1])
+
+		switch currentSection {
+		case "":
+			if err := assignRoot(&cfg, key, value); err != nil {
+				return Config{}, fmt.Errorf("line %d: %w", lineNum, err)
+			}
+		case "server":
+			if err := assignServer(&cfg.Server, key, value); err != nil {
+				return Config{}, fmt.Errorf("line %d: %w", lineNum, err)
+			}
+		case "registers":
+			if len(cfg.Registers) == 0 {
+				return Config{}, errors.New("register entry defined before [[registers]] header")
+			}
+			idx := len(cfg.Registers) - 1
+			if err := assignRegister(&cfg.Registers[idx], key, value); err != nil {
+				return Config{}, fmt.Errorf("line %d: %w", lineNum, err)
+			}
+		default:
+			return Config{}, fmt.Errorf("unknown section at line %d", lineNum)
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return Config{}, err
+	}
+
+	if cfg.Server.ListenAddress == "" {
+		cfg.Server.ListenAddress = ":1502"
+	}
+	if cfg.UpdateInterval == "" {
+		cfg.UpdateInterval = "5s"
+	}
+	if cfg.CSVFile == "" {
+		return Config{}, errors.New("csv_file must be set")
+	}
+	if len(cfg.Registers) == 0 {
+		return Config{}, errors.New("at least one register must be configured")
+	}
+
+	return cfg, nil
+}
+
+func assignRoot(cfg *Config, key, value string) error {
+	switch key {
+	case "csv_file":
+		cfg.CSVFile = parseString(value)
+	case "update_interval":
+		cfg.UpdateInterval = parseString(value)
+	default:
+		return fmt.Errorf("unknown key %s", key)
+	}
+	return nil
+}
+
+func assignServer(server *ServerSettings, key, value string) error {
+	switch key {
+	case "listen_address":
+		server.ListenAddress = parseString(value)
+	default:
+		return fmt.Errorf("unknown server key %s", key)
+	}
+	return nil
+}
+
+func assignRegister(reg *RegisterConfig, key, value string) error {
+	switch key {
+	case "type":
+		reg.Type = strings.ToLower(parseString(value))
+	case "address":
+		v, err := strconv.ParseUint(parseString(value), 10, 16)
+		if err != nil {
+			return fmt.Errorf("invalid address value: %w", err)
+		}
+		reg.Address = uint16(v)
+	case "csv_column":
+		reg.CSVColumn = parseString(value)
+	default:
+		return fmt.Errorf("unknown register key %s", key)
+	}
+	return nil
+}
+
+func parseString(value string) string {
+	value = strings.TrimSpace(value)
+	if strings.HasPrefix(value, "\"") && strings.HasSuffix(value, "\"") {
+		return strings.Trim(value, "\"")
+	}
+	return value
+}

--- a/internal/modbus/server.go
+++ b/internal/modbus/server.go
@@ -1,0 +1,292 @@
+package modbus
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"sync"
+)
+
+const (
+	functionReadCoils          = 0x01
+	functionReadDiscreteInputs = 0x02
+	functionReadHoldingRegs    = 0x03
+	functionReadInputRegs      = 0x04
+
+	exceptionIllegalFunction = 0x01
+	exceptionIllegalDataAddr = 0x02
+	exceptionIllegalDataVal  = 0x03
+)
+
+var (
+	errOutOfRange    = errors.New("out of range")
+	errInvalidQty    = errors.New("invalid quantity")
+	errInvalidPDULen = errors.New("invalid pdu length")
+)
+
+// Server implements a minimal Modbus TCP server that supports read functions.
+type Server struct {
+	listener  net.Listener
+	wg        sync.WaitGroup
+	quit      chan struct{}
+	closeOnce sync.Once
+
+	mu               sync.RWMutex
+	HoldingRegisters []uint16
+	InputRegisters   []uint16
+	Coils            []bool
+	DiscreteInputs   []bool
+}
+
+// NewServer constructs a server with default register sizes.
+func NewServer() *Server {
+	return &Server{
+		HoldingRegisters: make([]uint16, 65536),
+		InputRegisters:   make([]uint16, 65536),
+		Coils:            make([]bool, 65536),
+		DiscreteInputs:   make([]bool, 65536),
+		quit:             make(chan struct{}),
+	}
+}
+
+// Listen starts accepting Modbus TCP connections on the provided address.
+func (s *Server) Listen(address string) error {
+	l, err := net.Listen("tcp", address)
+	if err != nil {
+		return err
+	}
+	s.listener = l
+
+	s.wg.Add(1)
+	go s.acceptLoop()
+	return nil
+}
+
+func (s *Server) acceptLoop() {
+	defer s.wg.Done()
+	for {
+		conn, err := s.listener.Accept()
+		if err != nil {
+			select {
+			case <-s.quit:
+				return
+			default:
+			}
+			continue
+		}
+
+		s.wg.Add(1)
+		go s.handleConnection(conn)
+	}
+}
+
+func (s *Server) handleConnection(conn net.Conn) {
+	defer s.wg.Done()
+	defer conn.Close()
+
+	header := make([]byte, 7)
+	for {
+		if _, err := io.ReadFull(conn, header); err != nil {
+			return
+		}
+
+		length := binary.BigEndian.Uint16(header[4:6])
+		if length == 0 {
+			continue
+		}
+
+		pduLength := int(length - 1)
+		if pduLength <= 0 {
+			continue
+		}
+
+		unitID := header[6]
+		pdu := make([]byte, pduLength)
+		if _, err := io.ReadFull(conn, pdu); err != nil {
+			return
+		}
+
+		response := s.handlePDU(pdu)
+		if len(response) == 0 {
+			continue
+		}
+
+		binary.BigEndian.PutUint16(header[2:4], 0)
+		binary.BigEndian.PutUint16(header[4:6], uint16(len(response)+1))
+		header[6] = unitID
+
+		if _, err := conn.Write(header); err != nil {
+			return
+		}
+		if _, err := conn.Write(response); err != nil {
+			return
+		}
+	}
+}
+
+func (s *Server) handlePDU(pdu []byte) []byte {
+	if len(pdu) == 0 {
+		return exceptionResponse(0, exceptionIllegalFunction)
+	}
+
+	function := pdu[0]
+	switch function {
+	case functionReadCoils:
+		data, err := s.readBits(s.Coils, pdu)
+		if err != nil {
+			return exceptionResponse(function, errToCode(err))
+		}
+		return append([]byte{function, byte(len(data))}, data...)
+	case functionReadDiscreteInputs:
+		data, err := s.readBits(s.DiscreteInputs, pdu)
+		if err != nil {
+			return exceptionResponse(function, errToCode(err))
+		}
+		return append([]byte{function, byte(len(data))}, data...)
+	case functionReadHoldingRegs:
+		data, err := s.readRegisters(s.HoldingRegisters, pdu)
+		if err != nil {
+			return exceptionResponse(function, errToCode(err))
+		}
+		return append([]byte{function, byte(len(data))}, data...)
+	case functionReadInputRegs:
+		data, err := s.readRegisters(s.InputRegisters, pdu)
+		if err != nil {
+			return exceptionResponse(function, errToCode(err))
+		}
+		return append([]byte{function, byte(len(data))}, data...)
+	default:
+		return exceptionResponse(function, exceptionIllegalFunction)
+	}
+}
+
+func (s *Server) readBits(source []bool, pdu []byte) ([]byte, error) {
+	if len(pdu) < 5 {
+		return nil, errInvalidPDULen
+	}
+	start := binary.BigEndian.Uint16(pdu[1:3])
+	quantity := binary.BigEndian.Uint16(pdu[3:5])
+	if quantity == 0 || quantity > 2000 {
+		return nil, errInvalidQty
+	}
+	end := int(start) + int(quantity)
+	if end > len(source) {
+		return nil, errOutOfRange
+	}
+
+	byteCount := (int(quantity) + 7) / 8
+	result := make([]byte, byteCount)
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	for i := 0; i < int(quantity); i++ {
+		if source[int(start)+i] {
+			result[i/8] |= 1 << (uint(i) % 8)
+		}
+	}
+	return result, nil
+}
+
+func (s *Server) readRegisters(source []uint16, pdu []byte) ([]byte, error) {
+	if len(pdu) < 5 {
+		return nil, errInvalidPDULen
+	}
+	start := binary.BigEndian.Uint16(pdu[1:3])
+	quantity := binary.BigEndian.Uint16(pdu[3:5])
+	if quantity == 0 || quantity > 125 {
+		return nil, errInvalidQty
+	}
+	end := int(start) + int(quantity)
+	if end > len(source) {
+		return nil, errOutOfRange
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	result := make([]byte, quantity*2)
+	for i := 0; i < int(quantity); i++ {
+		binary.BigEndian.PutUint16(result[i*2:(i+1)*2], source[int(start)+i])
+	}
+	return result, nil
+}
+
+func exceptionResponse(function byte, code byte) []byte {
+	if function == 0 {
+		function = 0x80
+	} else {
+		function = function | 0x80
+	}
+	return []byte{function, code}
+}
+
+func errToCode(err error) byte {
+	switch {
+	case errors.Is(err, errOutOfRange):
+		return exceptionIllegalDataAddr
+	case errors.Is(err, errInvalidQty):
+		return exceptionIllegalDataVal
+	case errors.Is(err, errInvalidPDULen):
+		return exceptionIllegalDataVal
+	default:
+		return exceptionIllegalFunction
+	}
+}
+
+// Close stops the server and waits for all goroutines to exit.
+func (s *Server) Close() {
+	s.closeOnce.Do(func() {
+		close(s.quit)
+		if s.listener != nil {
+			s.listener.Close()
+		}
+	})
+	s.wg.Wait()
+}
+
+// SetHoldingRegister updates a holding register value.
+func (s *Server) SetHoldingRegister(address uint16, value uint16) error {
+	if int(address) >= len(s.HoldingRegisters) {
+		return fmt.Errorf("address %d out of range", address)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.HoldingRegisters[address] = value
+	return nil
+}
+
+// SetInputRegister updates an input register value.
+func (s *Server) SetInputRegister(address uint16, value uint16) error {
+	if int(address) >= len(s.InputRegisters) {
+		return fmt.Errorf("address %d out of range", address)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.InputRegisters[address] = value
+	return nil
+}
+
+// SetCoil updates a coil value.
+func (s *Server) SetCoil(address uint16, value bool) error {
+	if int(address) >= len(s.Coils) {
+		return fmt.Errorf("address %d out of range", address)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.Coils[address] = value
+	return nil
+}
+
+// SetDiscreteInput updates a discrete input value.
+func (s *Server) SetDiscreteInput(address uint16, value bool) error {
+	if int(address) >= len(s.DiscreteInputs) {
+		return fmt.Errorf("address %d out of range", address)
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.DiscreteInputs[address] = value
+	return nil
+}


### PR DESCRIPTION
## Summary
- implement a configurable Modbus TCP simulator that loads register bindings from TOML and cycles CSV data into the server
- build a lightweight Modbus TCP server with support for coil, discrete, holding, and input register reads
- add example configuration, sample CSV data, and documentation for running the simulator

## Testing
- go build ./cmd/server

------
https://chatgpt.com/codex/tasks/task_e_68d614777eb8832dbd2662caba6b4053