### PR TITLE
Add scaling and data type configuration for registers

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ registers with the configured values.
 - TOML configuration to define server settings, update interval, and register
   bindings.
 - CSV-driven data updates that cycle through rows on a fixed interval.
+- Optional scaling, offset, and data type conversion for numeric registers.
 
 ## Getting Started
 
@@ -58,6 +59,13 @@ supports the following Modbus function codes:
   - `type`: Register type (`holding`, `input`, `coil`, or `discrete`).
   - `address`: Register address to update.
   - `csv_column`: Column name in the CSV file to use for the register value.
+  - `scale`: Optional multiplier applied to the CSV value before it is written
+    to the register (defaults to `1`).
+  - `offset`: Optional value added after scaling (defaults to `0`).
+  - `data_type`: Optional numeric representation for holding and input
+    registers. Supported values are `uint16`, `int16`, and `float32`. Float32
+    values consume two consecutive registers starting at `address`.
 
 The simulator loops through the CSV rows continuously. Coil and discrete input
-values treat any non-zero CSV value as `true`.
+values treat any non-zero (after applying scale and offset) CSV value as
+`true`.

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -7,9 +7,11 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"math"
 	"os"
 	"os/signal"
 	"strconv"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -19,16 +21,19 @@ import (
 )
 
 type registerValue struct {
-	regType string
-	address uint16
-	column  string
+	regType  string
+	address  uint16
+	column   string
+	scale    float64
+	offset   float64
+	dataType string
 }
 
 type simulator struct {
 	cfg          config.Config
 	server       *modbus.Server
 	values       []registerValue
-	dataRows     []map[string]uint16
+	dataRows     []map[string]float64
 	updatePeriod time.Duration
 	mu           sync.Mutex
 	rowIndex     int
@@ -92,7 +97,39 @@ func newSimulator(cfg config.Config) (*simulator, error) {
 			server.Close()
 			return nil, fmt.Errorf("unsupported register type %s", reg.Type)
 		}
-		values[i] = registerValue{regType: reg.Type, address: reg.Address, column: reg.CSVColumn}
+
+		dataType := reg.DataType
+		switch reg.Type {
+		case "holding", "input":
+			if dataType == "" {
+				dataType = "uint16"
+			}
+			switch dataType {
+			case "uint16", "int16":
+			case "float32":
+				if reg.Address == 0xFFFF {
+					server.Close()
+					return nil, fmt.Errorf("register %s at address %d cannot fit float32 value", reg.Type, reg.Address)
+				}
+			default:
+				server.Close()
+				return nil, fmt.Errorf("unsupported data_type %s for %s register", dataType, reg.Type)
+			}
+		case "coil", "discrete":
+			if dataType != "" {
+				server.Close()
+				return nil, fmt.Errorf("data_type not supported for %s registers", reg.Type)
+			}
+		}
+
+		values[i] = registerValue{
+			regType:  reg.Type,
+			address:  reg.Address,
+			column:   reg.CSVColumn,
+			scale:    reg.Scale,
+			offset:   reg.Offset,
+			dataType: dataType,
+		}
 	}
 
 	rows, err := loadCSV(cfg.CSVFile)
@@ -112,7 +149,7 @@ func newSimulator(cfg config.Config) (*simulator, error) {
 	return sim, nil
 }
 
-func loadCSV(path string) ([]map[string]uint16, error) {
+func loadCSV(path string) ([]map[string]float64, error) {
 	file, err := os.Open(path)
 	if err != nil {
 		return nil, err
@@ -129,18 +166,22 @@ func loadCSV(path string) ([]map[string]uint16, error) {
 	}
 
 	header := records[0]
-	rows := make([]map[string]uint16, 0, len(records)-1)
+	rows := make([]map[string]float64, 0, len(records)-1)
 	for _, record := range records[1:] {
 		if len(record) != len(header) {
 			return nil, errors.New("csv record length mismatch")
 		}
-		row := make(map[string]uint16, len(header))
+		row := make(map[string]float64, len(header))
 		for i, key := range header {
-			val, err := strconv.ParseUint(record[i], 10, 16)
+			valStr := strings.TrimSpace(record[i])
+			if valStr == "" {
+				return nil, fmt.Errorf("empty value for column %s", key)
+			}
+			val, err := strconv.ParseFloat(valStr, 64)
 			if err != nil {
 				return nil, fmt.Errorf("invalid value for column %s: %w", key, err)
 			}
-			row[key] = uint16(val)
+			row[key] = val
 		}
 		rows = append(rows, row)
 	}
@@ -189,32 +230,107 @@ func (s *simulator) applyRowLocked(index int) {
 	}
 	row := s.dataRows[index]
 	for _, value := range s.values {
-		val, ok := row[value.column]
+		raw, ok := row[value.column]
 		if !ok {
 			log.Printf("column %s not found in csv data", value.column)
 			continue
 		}
+		scaled := raw*value.scale + value.offset
 		switch value.regType {
 		case "holding":
-			if err := s.server.SetHoldingRegister(value.address, val); err != nil {
+			if err := s.setNumericRegister(value, scaled); err != nil {
 				log.Printf("set holding register: %v", err)
 			}
 		case "input":
-			if err := s.server.SetInputRegister(value.address, val); err != nil {
+			if err := s.setNumericRegister(value, scaled); err != nil {
 				log.Printf("set input register: %v", err)
 			}
 		case "coil":
-			if err := s.server.SetCoil(value.address, val > 0); err != nil {
+			if err := s.server.SetCoil(value.address, scaled > 0); err != nil {
 				log.Printf("set coil: %v", err)
 			}
 		case "discrete":
-			if err := s.server.SetDiscreteInput(value.address, val > 0); err != nil {
+			if err := s.server.SetDiscreteInput(value.address, scaled > 0); err != nil {
 				log.Printf("set discrete input: %v", err)
 			}
 		default:
 			log.Printf("unsupported register type %s", value.regType)
 		}
 	}
+}
+
+func (s *simulator) setNumericRegister(value registerValue, scaled float64) error {
+	switch value.dataType {
+	case "uint16":
+		word, err := floatToUint16(scaled)
+		if err != nil {
+			return err
+		}
+		return s.setRegisterWord(value.regType, value.address, word)
+	case "int16":
+		word, err := floatToInt16(scaled)
+		if err != nil {
+			return err
+		}
+		return s.setRegisterWord(value.regType, value.address, word)
+	case "float32":
+		return s.setRegisterFloat32(value, scaled)
+	default:
+		return fmt.Errorf("unsupported data type %s", value.dataType)
+	}
+}
+
+func (s *simulator) setRegisterWord(regType string, address uint16, word uint16) error {
+	switch regType {
+	case "holding":
+		return s.server.SetHoldingRegister(address, word)
+	case "input":
+		return s.server.SetInputRegister(address, word)
+	default:
+		return fmt.Errorf("register type %s does not support word writes", regType)
+	}
+}
+
+func (s *simulator) setRegisterFloat32(value registerValue, scaled float64) error {
+	if math.IsNaN(scaled) || math.IsInf(scaled, 0) {
+		return fmt.Errorf("invalid float32 value for column %s", value.column)
+	}
+	if value.address == 0xFFFF {
+		return fmt.Errorf("address %d out of range for float32", value.address)
+	}
+	f32 := float32(scaled)
+	if math.IsInf(float64(f32), 0) {
+		return fmt.Errorf("value %f overflows float32", scaled)
+	}
+	bits := math.Float32bits(f32)
+	hi := uint16(bits >> 16)
+	lo := uint16(bits & 0xFFFF)
+	if err := s.setRegisterWord(value.regType, value.address, hi); err != nil {
+		return err
+	}
+	return s.setRegisterWord(value.regType, value.address+1, lo)
+}
+
+func floatToUint16(value float64) (uint16, error) {
+	if math.IsNaN(value) || math.IsInf(value, 0) {
+		return 0, fmt.Errorf("invalid uint16 value")
+	}
+	rounded := math.Round(value)
+	if rounded < 0 || rounded > 65535 {
+		return 0, fmt.Errorf("value %f out of range for uint16", value)
+	}
+	return uint16(rounded), nil
+}
+
+func floatToInt16(value float64) (uint16, error) {
+	if math.IsNaN(value) || math.IsInf(value, 0) {
+		return 0, fmt.Errorf("invalid int16 value")
+	}
+	rounded := math.Round(value)
+	if rounded < -32768 || rounded > 32767 {
+		return 0, fmt.Errorf("value %f out of range for int16", value)
+	}
+	return uint16(int16(rounded)), nil
 }
 
 func (s *simulator) Close() {

--- a/config.example.toml
+++ b/config.example.toml
@@ -8,11 +8,15 @@ listen_address = ":1502"
 type = "holding"
 address = 1
 csv_column = "temperature"
+scale = 10
+data_type = "uint16"
 
 [[registers]]
 type = "input"
 address = 0
 csv_column = "humidity"
+scale = 10
+offset = 100
 
 [[registers]]
 type = "coil"
@@ -23,3 +27,9 @@ csv_column = "pump"
 type = "discrete"
 address = 2
 csv_column = "alarm"
+
+[[registers]]
+type = "holding"
+address = 10
+csv_column = "flow_rate"
+data_type = "float32"

--- a/config.topway.toml
+++ b/config.topway.toml
@@ -8,61 +8,73 @@ listen_address = ":1502"
 type = "holding"
 address = 0
 csv_column = "pretreatment_concentration_mg_l"
+scale = 100
 
 [[registers]]
 type = "holding"
 address = 1
 csv_column = "pretreatment_total_chlorine_mg_l"
+scale = 100
 
 [[registers]]
 type = "holding"
 address = 2
 csv_column = "pretreatment_residual_chlorine_mg_l"
+scale = 100
 
 [[registers]]
 type = "holding"
 address = 3
 csv_column = "eyedrop_concentration_mg_l"
+scale = 100
 
 [[registers]]
 type = "holding"
 address = 4
 csv_column = "eyedrop_total_chlorine_mg_l"
+scale = 100
 
 [[registers]]
 type = "holding"
 address = 5
 csv_column = "eyedrop_residual_chlorine_mg_l"
+scale = 100
 
 [[registers]]
 type = "holding"
 address = 6
 csv_column = "water_treatment_turbidity_ntu"
+scale = 100
 
 [[registers]]
 type = "holding"
 address = 7
 csv_column = "water_treatment_residual_chlorine_mg_l"
+scale = 100
 
 [[registers]]
 type = "holding"
 address = 8
 csv_column = "water_treatment_temperature_c"
+scale = 10
 
 [[registers]]
 type = "holding"
 address = 9
 csv_column = "supply_tank_level_m"
+scale = 100
 
 [[registers]]
 type = "holding"
 address = 10
 csv_column = "supply_tank_temperature_c"
+scale = 10
 
 [[registers]]
 type = "holding"
 address = 11
 csv_column = "supply_tank_ph"
+scale = 100
 
 [[registers]]
 type = "holding"
@@ -73,6 +85,7 @@ csv_column = "eyedrop_ec_us_cm"
 type = "holding"
 address = 13
 csv_column = "eyedrop_temperature_c"
+scale = 10
 
 [[registers]]
 type = "holding"
@@ -83,3 +96,4 @@ csv_column = "water_treatment_ec_us_cm"
 type = "holding"
 address = 15
 csv_column = "water_treatment_ph"
+scale = 100

--- a/data/example_data.csv
+++ b/data/example_data.csv
@@ -1,5 +1,5 @@
-temperature,humidity,pump,alarm
-21,55,0,0
-22,58,1,0
-23,60,1,1
-24,57,0,0
+temperature,humidity,pump,alarm,flow_rate
+21.5,55.2,0,0,12.4
+22.1,58.0,1,0,12.8
+23.3,60.4,1,1,12.6
+24.0,57.9,0,0,12.5

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -24,6 +24,9 @@ type RegisterConfig struct {
 	Type      string
 	Address   uint16
 	CSVColumn string
+	Scale     float64
+	Offset    float64
+	DataType  string
 }
 
 func Load(path string) (Config, error) {
@@ -53,7 +56,7 @@ func Load(path string) (Config, error) {
 				section = strings.Trim(section, "[]")
 			}
 			if section == "registers" && strings.HasPrefix(line, "[[") {
-				cfg.Registers = append(cfg.Registers, RegisterConfig{})
+				cfg.Registers = append(cfg.Registers, RegisterConfig{Scale: 1})
 				currentSection = "registers"
 			} else if section == "server" {
 				currentSection = "server"
@@ -146,6 +149,20 @@ func assignRegister(reg *RegisterConfig, key, value string) error {
 		reg.Address = uint16(v)
 	case "csv_column":
 		reg.CSVColumn = parseString(value)
+	case "scale":
+		v, err := strconv.ParseFloat(parseString(value), 64)
+		if err != nil {
+			return fmt.Errorf("invalid scale value: %w", err)
+		}
+		reg.Scale = v
+	case "offset":
+		v, err := strconv.ParseFloat(parseString(value), 64)
+		if err != nil {
+			return fmt.Errorf("invalid offset value: %w", err)
+		}
+		reg.Offset = v
+	case "data_type":
+		reg.DataType = strings.ToLower(parseString(value))
 	default:
 		return fmt.Errorf("unknown register key %s", key)
 	}


### PR DESCRIPTION
## Summary
- add support for scale, offset, and data_type fields in register configuration parsing
- allow the simulator to read floating point CSV data, apply scaling/offset, and encode uint16/int16/float32 values when updating registers
- update documentation, sample configuration, and example data to demonstrate the new options

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68da163f9068832db39a3dfc8a4dbdf6